### PR TITLE
Track delivered messages before cleaning dead sockets

### DIFF
--- a/services/gateway/src/main.py
+++ b/services/gateway/src/main.py
@@ -42,12 +42,13 @@ async def publish(body: PublishIn):
         except Exception:
             dead.add(ws)
 
+    total = len(SUBS[topic])  # contar antes de limpiar para saber cuántos reciben
     # limpiar sockets muertos
     for ws in dead:
         for t in SUBS.values():
             t.discard(ws)
 
-    return {"delivered": len(SUBS[topic]) - len(dead)}
+    return {"delivered": total - len(dead)}
 
 @app.websocket("/ws")
 async def ws_endpoint(ws: WebSocket):


### PR DESCRIPTION
## Summary
- preserve subscriber count before removing inactive sockets
- report delivered messages based on original count after cleanup

## Testing
- `python -m pytest`
- `python -m py_compile services/gateway/src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad2d4f2ef883228726bd0652cbf8a8