### PR TITLE
feat: encode emotions using markers

### DIFF
--- a/services/tts/src/engine.py
+++ b/services/tts/src/engine.py
@@ -13,13 +13,13 @@ from typing import Dict, Optional
 import os
 import yaml
 
-# Load emotion to speaker preset mapping from YAML
+# Load emotion to text marker mapping from YAML
 _PRESETS_PATH = Path(__file__).parent / "voices" / "presets.yaml"
 if _PRESETS_PATH.exists():
     with open(_PRESETS_PATH, "r", encoding="utf-8") as f:
-        EMOTION_PRESET_MAP: Dict[str, str] = yaml.safe_load(f) or {}
+        EMOTION_MARKER_MAP: Dict[str, str] = yaml.safe_load(f) or {}
 else:
-    EMOTION_PRESET_MAP = {}
+    EMOTION_MARKER_MAP = {}
 
 class TTSEngine:
     """Wrapper around the Fish Audio pipeline."""
@@ -50,12 +50,13 @@ class TTSEngine:
         a placeholder byte string is produced so tests can run without the
         heavy model dependencies.
         """
-        preset = EMOTION_PRESET_MAP.get(emotion, EMOTION_PRESET_MAP.get("neutral", "neutral"))
+        marker = EMOTION_MARKER_MAP.get(emotion, EMOTION_MARKER_MAP.get("neutral", "neutral"))
+        text_with_marker = f"({marker}) {text}"
         if self._pipeline is None:
             # Fallback stub representation
-            return f"[{preset}] {text}".encode("utf-8")
+            return text_with_marker.encode("utf-8")
 
-        result = self._pipeline(text, speaker=preset)
+        result = self._pipeline(text_with_marker)
         audio = result.get("audio")
         if isinstance(audio, bytes):
             return audio

--- a/services/tts/src/voices/presets.yaml
+++ b/services/tts/src/voices/presets.yaml
@@ -1,3 +1,4 @@
+# Mapping from conversation emotion labels to Fish Speech style markers
 neutral: neutral
 happy: cheerful
 angry: angry
@@ -5,7 +6,7 @@ sad: sad
 thinking: thinking
 surprised: surprised
 sleeping: sleep
-upset: upset
+upset: angry
 fear: fear
 asco: disgust
 love: loving

--- a/services/tts/tests/test_engine.py
+++ b/services/tts/tests/test_engine.py
@@ -3,12 +3,12 @@ import sys
 import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from src.engine import TTSEngine, EMOTION_PRESET_MAP
+from src.engine import TTSEngine, EMOTION_MARKER_MAP
 
 engine = TTSEngine()
 
-@pytest.mark.parametrize("emotion", sorted(EMOTION_PRESET_MAP.keys()))
+@pytest.mark.parametrize("emotion", sorted(EMOTION_MARKER_MAP.keys()))
 def test_synthesize_returns_bytes(emotion):
     audio = engine.synthesize("hola", emotion)
     assert isinstance(audio, bytes)
-    assert audio.startswith(f"[{EMOTION_PRESET_MAP.get(emotion)}]".encode())
+    assert audio.startswith(f"({EMOTION_MARKER_MAP.get(emotion)}) ".encode())

--- a/services/tts/tests/test_server.py
+++ b/services/tts/tests/test_server.py
@@ -24,4 +24,4 @@ def test_speak_endpoint():
     assert data["reply"] == "hola"
     assert data["emotion"] == "happy"
     audio = base64.b64decode(data["audio_b64"])  # should start with our placeholder
-    assert audio.startswith(b"[cheerful]")
+    assert audio.startswith(b"(cheerful) ")


### PR DESCRIPTION
## Summary
- map conversation emotions to Fish Speech markers
- synthesize speech by prefixing markers inside the text
- update tests for new emotion encoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad5177a614832285ba5ede9706aee1